### PR TITLE
add some starknet rpc

### DIFF
--- a/cairo/api.go
+++ b/cairo/api.go
@@ -2,6 +2,9 @@ package cairo
 
 import (
 	"errors"
+	"net/http"
+	"slices"
+
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/encoder"
@@ -12,8 +15,6 @@ import (
 	"github.com/yu-org/yu/common"
 	"github.com/yu-org/yu/core/context"
 	"github.com/yu-org/yu/core/types"
-	"net/http"
-	"slices"
 )
 
 type BlockID struct {
@@ -30,6 +31,22 @@ func NewFromJunoBlockID(id rpc.BlockID) BlockID {
 		Hash:    id.Hash,
 		Number:  id.Number,
 	}
+}
+
+type LatestBlockResponse struct {
+	Block *types.CompactBlock `json:"latest_block"`
+	Err   *jsonrpc.Error      `json:"err"`
+}
+
+// 不是很确定这里是不是其实不需要request的内容，直接response
+func (c *Cairo) LatestBlock(ctx *context.ReadContext) {
+	Block, err := c.Chain.GetEndBlock()
+	if err != nil {
+		ctx.Json(http.StatusInternalServerError, &LatestBlockResponse{Err: jsonrpc.Err(jsonrpc.InternalError, err.Error())})
+		return
+	}
+	// Height := uint64(Block.Height)
+	ctx.JsonOk(&LatestBlockResponse{Block: Block})
 }
 
 type TransactionRequest struct {

--- a/cairo/cairo.go
+++ b/cairo/cairo.go
@@ -2,6 +2,9 @@ package cairo
 
 import (
 	"encoding/hex"
+	"itachi/cairo/config"
+	"net/http"
+
 	junostate "github.com/NethermindEth/juno/blockchain"
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
@@ -16,8 +19,6 @@ import (
 	"github.com/yu-org/yu/core/context"
 	"github.com/yu-org/yu/core/tripod"
 	"github.com/yu-org/yu/core/types"
-	"itachi/cairo/config"
-	"net/http"
 )
 
 type Cairo struct {
@@ -59,6 +60,7 @@ func NewCairo(cfg *config.Config) *Cairo {
 		cairo.GetTransaction, cairo.GetTransactionStatus, cairo.GetReceipt,
 		cairo.SimulateTransactions,
 		cairo.GetBlockWithTxs, cairo.GetBlockWithTxHashes,
+		cairo.LatestBlock,
 	)
 	cairo.SetInit(cairo)
 	cairo.SetTxnChecker(cairo)

--- a/cairo/starknetrpc/methods.go
+++ b/cairo/starknetrpc/methods.go
@@ -4,22 +4,164 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+
 	"github.com/NethermindEth/juno/core"
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/juno/jsonrpc"
 	"github.com/NethermindEth/juno/rpc"
 	"github.com/NethermindEth/juno/utils"
+
+	// "github.com/NethermindEth/juno/db"
+
+	// "github.com/NethermindEth/juno/blockchain"
+	"itachi/cairo"
+
 	"github.com/NethermindEth/starknet.go/hash"
 	sdk "github.com/NethermindEth/starknet.go/rpc"
 	"github.com/yu-org/yu/common"
 	yucore "github.com/yu-org/yu/core"
 	yucontext "github.com/yu-org/yu/core/context"
-	"itachi/cairo"
 )
 
 func (s *StarknetRPC) GetChainID() (*felt.Felt, *jsonrpc.Error) {
 	return s.network.ChainID(), nil
 }
+
+func (s *StarknetRPC) BlockNumber() (uint64, *jsonrpc.Error) {
+	// num, _ := s.bcReader.Height()
+	// return num, nil
+	resp, err := s.adaptChainRead(nil, "LatestBlock")
+	if err != nil {
+		return 0, rpc.ErrNoBlock
+	}
+	res := resp.DataInterface.(*cairo.LatestBlockResponse)
+	return uint64(res.Block.Height), res.Err
+}
+
+func (s *StarknetRPC) BlockHashAndNumber() (*rpc.BlockHashAndNumber, *jsonrpc.Error) {
+	// block, err := s.bcReader.Head()
+	// if err != nil {
+	// 	return nil, rpc.ErrBlockNotFound
+	// }
+	// return &rpc.BlockHashAndNumber{Number: block.Number, Hash: block.Hash}, nil
+	resp, err := s.adaptChainRead(nil, "LatestBlock")
+	if err != nil {
+		return nil, rpc.ErrNoBlock
+	}
+	res := resp.DataInterface.(*cairo.LatestBlockResponse)
+	return &rpc.BlockHashAndNumber{Number: uint64(res.Block.Height), Hash: new(felt.Felt).SetBytes(res.Block.Hash.Bytes())}, nil
+}
+
+// func (s *StarknetRPC) GetStateUpdate(id rpc.BlockID) (*rpc.StateUpdate, *jsonrpc.Error) {
+// 	var update *core.StateUpdate
+// 	var err error
+// 	if id.Latest {
+// 		if height, heightErr := s.bcReader.Height(); heightErr != nil {
+// 			err = heightErr
+// 		} else {
+// 			update, err = s.bcReader.StateUpdateByNumber(height)
+// 		}
+// 	} else if id.Pending {
+// 		var pending blockchain.Pending
+// 		pending, err = s.bcReader.Pending()
+// 		if err == nil {
+// 			update = pending.StateUpdate
+// 		}
+// 	} else if id.Hash != nil {
+// 		update, err = s.bcReader.StateUpdateByHash(id.Hash)
+// 	} else {
+// 		update, err = s.bcReader.StateUpdateByNumber(id.Number)
+// 	}
+// 	if err != nil {
+// 		if errors.Is(err, db.ErrKeyNotFound) {
+// 			return nil, rpc.ErrBlockNotFound
+// 		}
+// 		return nil, rpc.ErrInternal.CloneWithData(err)
+// 	}
+
+// 	nonces := make([]rpc.Nonce, 0, len(update.StateDiff.Nonces))
+// 	for addr, nonce := range update.StateDiff.Nonces {
+// 		nonces = append(nonces, rpc.Nonce{ContractAddress: addr, Nonce: *nonce})
+// 	}
+
+// 	storageDiffs := make([]rpc.StorageDiff, 0, len(update.StateDiff.StorageDiffs))
+// 	for addr, diffs := range update.StateDiff.StorageDiffs {
+// 		entries := make([]rpc.Entry, 0, len(diffs))
+// 		for key, value := range diffs {
+// 			entries = append(entries, rpc.Entry{
+// 				Key:   key,
+// 				Value: *value,
+// 			})
+// 		}
+
+// 		storageDiffs = append(storageDiffs, rpc.StorageDiff{
+// 			Address:        addr,
+// 			StorageEntries: entries,
+// 		})
+// 	}
+
+// 	deployedContracts := make([]rpc.DeployedContract, 0, len(update.StateDiff.DeployedContracts))
+// 	for addr, classHash := range update.StateDiff.DeployedContracts {
+// 		deployedContracts = append(deployedContracts, rpc.DeployedContract{
+// 			Address:   addr,
+// 			ClassHash: *classHash,
+// 		})
+// 	}
+
+// 	declaredClasses := make([]rpc.DeclaredClass, 0, len(update.StateDiff.DeclaredV1Classes))
+// 	for classHash, compiledClassHash := range update.StateDiff.DeclaredV1Classes {
+// 		declaredClasses = append(declaredClasses, rpc.DeclaredClass{
+// 			ClassHash:         classHash,
+// 			CompiledClassHash: *compiledClassHash,
+// 		})
+// 	}
+
+// 	replacedClasses := make([]rpc.ReplacedClass, 0, len(update.StateDiff.ReplacedClasses))
+// 	for addr, classHash := range update.StateDiff.ReplacedClasses {
+// 		replacedClasses = append(replacedClasses, rpc.ReplacedClass{
+// 			ClassHash:       *classHash,
+// 			ContractAddress: addr,
+// 		})
+// 	}
+
+// 	return &rpc.StateUpdate{
+// 		BlockHash: update.BlockHash,
+// 		OldRoot:   update.OldRoot,
+// 		NewRoot:   update.NewRoot,
+// 		StateDiff: &rpc.StateDiff{
+// 			DeprecatedDeclaredClasses: update.StateDiff.DeclaredV0Classes,
+// 			DeclaredClasses:           declaredClasses,
+// 			ReplacedClasses:           replacedClasses,
+// 			Nonces:                    nonces,
+// 			StorageDiffs:              storageDiffs,
+// 			DeployedContracts:         deployedContracts,
+// 		},
+// 	}, nil
+// }
+
+// func (s *StarknetRPC) Syncing() (*rpc.Sync, *jsonrpc.Error) {
+// 	return nil, nil
+// }
+
+// func (s *StarknetRPC) TraceTransaction(ctx context.Context, hash felt.Felt) (*vm.TransactionTrace, *jsonrpc.Error) {
+// 	receipt, err := s.GetReceiptByHash(hash)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	blockhash := receipt.BlockHash
+// 	if blockhash == nil {
+
+// 	}
+// }
+
+// func (s *StarknetRPC) TraceBlockTransactions() () {}
+
+// func (s *StarknetRPC) traceTransaction(ctx context.Context, blockHash *felt.Felt) ([]rpc.TracedBlockTransaction, *jsonrpc.Error) {
+// 	// not pending
+// 	if blockHash != nil {
+
+// 	}
+// }
 
 func (s *StarknetRPC) GetBlockWithTxHashes(id rpc.BlockID) (*rpc.BlockWithTxHashes, *jsonrpc.Error) {
 	req := &cairo.BlockWithTxHashesRequest{BlockID: cairo.NewFromJunoBlockID(id)}
@@ -110,6 +252,46 @@ func (s *StarknetRPC) Call(call rpc.FunctionCall, id rpc.BlockID) ([]*felt.Felt,
 	return cr.ReturnData, cr.Err
 }
 
+func (s *StarknetRPC) EstimateMessageFee(msg rpc.MsgFromL1, id rpc.BlockID) (*rpc.FeeEstimate, *jsonrpc.Error) {
+	feeEstimate, err := s.estimateMessageFee(msg, id, s.EstimateFee)
+	if err != nil {
+		return nil, err
+	}
+	return feeEstimate, nil
+}
+
+type estimateFeeHandler func(broadcastedTxns []rpc.BroadcastedTransaction,
+	simulationFlags []rpc.SimulationFlag, id rpc.BlockID,
+) ([]rpc.FeeEstimate, *jsonrpc.Error)
+
+func (s *StarknetRPC) estimateMessageFee(
+	msg rpc.MsgFromL1,
+	id rpc.BlockID,
+	f estimateFeeHandler,
+) (*rpc.FeeEstimate, *jsonrpc.Error) {
+	calldata := make([]*felt.Felt, 0, len(msg.Payload)+1)
+	// The order of the calldata parameters matters. msg.From must be prepended.
+	calldata = append(calldata, new(felt.Felt).SetBytes(msg.From.Bytes()))
+	for payloadIdx := range msg.Payload {
+		calldata = append(calldata, &msg.Payload[payloadIdx])
+	}
+	tx := rpc.BroadcastedTransaction{
+		Transaction: rpc.Transaction{
+			Type:               rpc.TxnL1Handler,
+			ContractAddress:    &msg.To,
+			EntryPointSelector: &msg.Selector,
+			CallData:           &calldata,
+			Version:            &felt.Zero, // Needed for transaction hash calculation.
+			Nonce:              &felt.Zero, // Needed for transaction hash calculation.
+		},
+		// Needed to marshal to blockifier type.
+		// Must be greater than zero to successfully execute transaction.
+		PaidFeeOnL1: new(felt.Felt).SetUint64(1),
+	}
+	estimates, _ := f([]rpc.BroadcastedTransaction{tx}, nil, id)
+	return &estimates[0], nil
+}
+
 func (s *StarknetRPC) EstimateFee(broadcastedTxns []rpc.BroadcastedTransaction,
 	simulationFlags []rpc.SimulationFlag, id rpc.BlockID,
 ) ([]rpc.FeeEstimate, *jsonrpc.Error) {
@@ -182,6 +364,54 @@ func (s *StarknetRPC) GetTransactionByHash(hash felt.Felt) (*rpc.Transaction, *j
 	}
 	tr := resp.DataInterface.(*cairo.TransactionResponse)
 	return tr.Tx, tr.Err
+}
+
+func (s *StarknetRPC) GetBlockTransactionCount(id rpc.BlockID) (uint64, *jsonrpc.Error) {
+	blockWithTxs, err := s.GetBlockWithTxs(id)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(len(blockWithTxs.Transactions)), err
+}
+
+func (s *StarknetRPC) GetTransactionByBlockIdAndIndex(id rpc.BlockID, txIndex int) (*rpc.Transaction, *jsonrpc.Error) {
+	if txIndex < 0 {
+		return nil, rpc.ErrInvalidTxIndex
+	}
+
+	blockWithTxHashes, err := s.GetBlockWithTxHashes(id)
+	if err != nil {
+		return nil, err
+	}
+	hash := *blockWithTxHashes.TxnHashes[txIndex] //不是很确定这里是不是直接可以用index
+
+	txReq := &cairo.TransactionRequest{Hash: hash}
+	resp, jsonErr := s.adaptChainRead(txReq, "GetTransaction")
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+	tr := resp.DataInterface.(*cairo.TransactionResponse)
+	return tr.Tx, tr.Err
+
+	// if id.Pending {
+	// 	pending, err := s.bcReader.Pending()
+	// 	if err != nil {
+	// 		return nil, rpc.ErrBlockNotFound
+	// 	}
+
+	// 	if uint64(txIndex) > pending.Block.TransactionCount {
+	// 		return nil, rpc.ErrInvalidTxIndex
+	// 	}
+
+	// 	hash := *pending.Block.Transactions[txIndex].Hash()
+	// 	txReq := &cairo.TransactionRequest{Hash: hash}
+	// 	resp, jsonErr := s.adaptChainRead(txReq, "GetTransaction")
+	// 	if jsonErr != nil {
+	// 		return nil, jsonErr
+	// 	}
+	// 	tr := resp.DataInterface.(*cairo.TransactionResponse)
+	// 	return tr.Tx, tr.Err
+	// }
 }
 
 func (s *StarknetRPC) GetTransactionStatus(ctx context.Context, hash felt.Felt) (*rpc.TransactionStatus, *jsonrpc.Error) {


### PR DESCRIPTION
目前还没写：`GetStateUpdate`， `Syncing`， `TraceTransaction`， `traceBlockTransactions`

假如改动`type StarknetRPC struct`：

```go
type StarknetRPC struct {
	chain    *kernel.Kernel
	log      utils.SimpleLogger
	srv      *http.Server
	network  utils.Network
	bcReader blockchain.Reader
}
	
```

然后相应的在`NewStarknetRPC`方法中初始化：

```go
var database db.DB
database, err = pebble.New(cfg.DbPath, cfg.DbCache, cfg.DbMaxOpenFiles, log)
if err != nil {
	return nil, err
}
reader := blockchain.New(database, s.network)
s.bcReader = reader
```

就会让

```go
func (s *StarknetRPC) BlockHashAndNumber() (*rpc.BlockHashAndNumber, *jsonrpc.Error) {
	block, err := s.bcReader.Head()
	if err != nil {
		return nil, rpc.ErrBlockNotFound
	}
	return &rpc.BlockHashAndNumber{Number: block.Number, Hash: block.Hash}, nil
}
```

之类的方法写起来很简单，但我不太知道**<u>哪些时候能直接调用juno的函数</u>**。我有点迷糊yu和juno的关系，itachi是以yu为链然后来跟cairoVM交互的吗，所以查询链上数据的时候用yu的函数？比如yu的`GetEndBlock`

那么这样的话是否是这样的一个流程：

在methods.go文件下写rpc的实现

```go
func (s *StarknetRPC) BlockNumber() (uint64, *jsonrpc.Error) {
    // 这里也是直接用juno的bcReader会很简单
	// num, _ := s.bcReader.Height()
	// return num, nil
	resp, err := s.adaptChainRead(nil, "BlockNumber")
	if err != nil {
		return 0, rpc.ErrNoBlock
	}
	res := resp.DataInterface.(*cairo.BlockNumberResponse)
	return res.Height, res.Err
}
```

然后在api.go下

```go
type BlockNumberResponse struct {
	Height uint64         `json:"block_number"`
	Err    *jsonrpc.Error `json:"err"`
}

// 不是很确定这里是不是可以不写request，直接response
func (c *Cairo) BlockNumber(ctx *context.ReadContext) {
	Block, err := c.Chain.GetEndBlock()
	if err != nil {
		ctx.Json(http.StatusInternalServerError, &BlockNumberResponse{Err: jsonrpc.Err(jsonrpc.InternalError, err.Error())})
		return
	}
	Height := uint64(Block.Height)
	ctx.JsonOk(&BlockNumberResponse{Height: Height})
}
```

然后再在cairo.go里面注册一个reading方法.

`traceBlockTransactions`: juno用来追踪transaction的方法，其中要求starknet version小于0.12.3，我看starknet已经更新到0.13.1.1了，这个version是定义在core.Block的Header里面的，我没在yu的header里找到这个字段，这个限制是必要的吗

```go
if blockVer, err := core.ParseBlockVersion(block.ProtocolVersion); err != nil {
			return nil, ErrUnexpectedError.CloneWithData(err.Error())
		} else if blockVer.Compare(traceFallbackVersion) != 1 || h.forceFeederTracesForBlocks.Contains(block.Number) {
			// version <= 0.12.3 or forcing fetch some blocks from feeder gateway
			return h.fetchTraces(ctx, block.Hash)
		}
```

然后这个`forceFeederTracesForBlocks`我看到mainnet有预定义一长串的blocknumber，其他网络都没有，不太清楚为什么这些预定义的区块要强制trace

`feeder.Client`还没细看，如果要用到的话是否要用network里的feeder url自己实现一个feeder client？

我看juno代码理解的是找feeder client获取trace。`fetchTraces`-->`feederClient.BlockTrace`-->`buildQueryString`

对我来说难点主要在于找到yu框架中对应的方法来复刻juno这个流程。

然后juno维护了一个traceCache，这个要做吗？（倒是做起来很简单，StarknetRPC结构体里面加一个*lru.Cache[traceCacheKey, []TracedBlockTransaction]就行）

juno的Block里的ParentHash是否就是yu的PrevHash？

```go
	state, closer, err := h.bcReader.StateAtBlockHash(block.ParentHash)
	if err != nil {
		return nil, ErrBlockNotFound
	}
	defer h.callAndLogErr(closer, "Failed to close state in traceBlockTransactions")
```

state是一个stateReader，这个其实也是能直接用bcreader就很方便。



`Syncing()`其实也是一样的问题，不知道能不能用juno的syncreader，能用最简单。

`GetStateUpdate()`也是用bcreader最方便。

